### PR TITLE
Handle log issues

### DIFF
--- a/Distance.py
+++ b/Distance.py
@@ -13,21 +13,27 @@ QSOfile = open("wsjtx.log","r")
 
 LineCount = 0
 DistanceAcc = 0
-StartYear = 2020
+StartYear = 2015
+MyGrid = "FN21xb90"
 DistanceAcc = [0]*10  # allow for 10 years
 
 for line in QSOfile:
-    LineCount += 1
-
     Values = line.split(",")
-    Year = int(Values[0][0:4])
+    try:
+        Year = int(Values[0][0:4])
+    except:
+        continue
     Grid = Values[5]
     if (Grid != ''):
-        Distance = calculate_distance("FN42kn96", Grid)
-        DistanceAcc[Year-StartYear] += Distance
+        try:
+            Distance = calculate_distance(MyGrid, Grid)
+            DistanceAcc[Year-StartYear] += Distance
+        except:
+            continue
+    LineCount += 1
 QSOfile.close()
 
-print("Found {} Lines in file".format(LineCount))
+print("Found {} valid lines in file".format(LineCount))
 
 for year in range(len(DistanceAcc)):
     if DistanceAcc[year] > 0:


### PR DESCRIPTION
This adds some simple code to try to handle errors found in the log file, due to incompatibility with earlier log formats or partially corrupted logs. If there are errors either parsing the year or calculating the distance for a specific line, that line is skipped. 

I also move the home grid to a variable, changed the start date, and only count valid lines in the file (instead of all).